### PR TITLE
Error when clicking on channel too quickly

### DIFF
--- a/html/js/subscriber.js
+++ b/html/js/subscriber.js
@@ -32,8 +32,7 @@ function updateChannels(channels) {
 			channelsEle.appendChild(c);
 		});
 	}
-	document.getElementById('channels').classList.remove('hidden');
-	document.getElementById('reload').classList.remove('hidden');
+
 };
 
 ws.onmessage = function (e)	{
@@ -53,6 +52,12 @@ ws.onmessage = function (e)	{
 				break;
 			case 'channels':
 				updateChannels(wsMsg.Value);
+				break;
+			case "session_established": // wait for the message that session_subscriber was received
+				document.getElementById("channels").classList.remove("hidden");
+				document.getElementById('reload').classList.remove('hidden');
+				document.getElementById("spinner").classList.add("hidden");
+				console.log("session_established");
 				break;
 			case 'ice_candidate':
 				pc.addIceCandidate(wsMsg.Value)

--- a/http.go
+++ b/http.go
@@ -138,6 +138,13 @@ func wsHandler(w http.ResponseWriter, r *http.Request) {
 				c.errChan <- err
 				continue
 			}
+			// If there is no error, send a success message
+			m := wsMsg{Key: "session_established"}
+			err = c.writeMsg(m)
+			if err != nil {
+				c.logger.Error(err.Error())
+				continue
+			}
 		case "session_publisher":
 			var offer webrtc.SessionDescription
 			err = json.Unmarshal(msg.Value, &offer)


### PR DESCRIPTION
As a subscriber, when I click on a channel just after the channel buttons appear, I encounter this error:
![grafik](https://github.com/porjo/babelcast/assets/86522026/72b95d9c-1e42-4e46-8bbd-17886c462777)

I added a couple of lines so that the server is sending a message after it receives the session_subscriber message from the client. Only after this session_established message is received, the channel buttons are unhidden. 

This makes sure that the user will click on the channels only after the server is ready to connect the subscriber.

Tested on Windows, Firefox and Chrome

By the way thanks a lot for this amazing little tool. Its exactly what I needed!